### PR TITLE
Fix warning message: "Interpolation-only expressions are deprecated"

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,12 @@
 
 output "management_server_ip" {
-  value = "${data.aws_instance.management_server.public_ip}"
+  value = "data.aws_instance.management_server.public_ip"
 }
 
 output "first_datanode_ip" {
-  value = "${data.aws_instance.exasol_first_datanode.public_ip}"
+  value = "data.aws_instance.exasol_first_datanode.public_ip"
 }
 
 output "exasol_waited_on" {
-  value = "${null_resource.exasol_waited_on.id}"
+  value = "null_resource.exasol_waited_on.id"
 }


### PR DESCRIPTION
Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Since the required terraform version is ">= 0.12" for this module removed interpolation-only expressions from outputs.tf file